### PR TITLE
Fix version in eredis.app.src

### DIFF
--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,6 +1,6 @@
 {application, eredis, [
     {description, "Erlang Redis Client"},
-    {vsn, "0.3.0"},
+    {vsn, "0.4.0"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib]}


### PR DESCRIPTION
Hi,

Repository is tagged with v0.4.0 but eredis.app.src says 0.3.0 which makes rebar get-deps unhappy
