### PR TITLE
Dynamic ReconnectSleep time and direct Poolboy support

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -15,7 +15,7 @@
 %% Specified in http://www.erlang.org/doc/man/gen_server.html#call-3
 -define(TIMEOUT, 5000).
 
--export([start_link/0, start_link/2, start_link/3, start_link/4,
+-export([start_link/0, start_link/1, start_link/2, start_link/3, start_link/4,
          start_link/5, q/2, q/3]).
 
 %% Exported for testing
@@ -24,6 +24,18 @@
 %%
 %% PUBLIC API
 %%
+
+%% -type Args = [Option].
+%% -type Option = {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, integer()}.
+-spec start_link( Args :: list() ) -> {ok, Pid::pid()} | {error, Reason::term()}.
+start_link(Args) ->
+    Host = proplists:get_value(host, Args, "127.0.0.1"),
+    Port = proplists:get_value(port, Args, 6379),
+    Database = proplists:get_value(database, Args, 0),
+    Password = proplists:get_value(password, Args, ""),
+    ReconnectSleep = proplists:get_value(reconnect_sleep, Args, 100),
+    eredis_client:start_link(Host, Port, Database, Password, ReconnectSleep).
+
 
 -spec start_link() -> {ok, Client::pid()} |
                           {error, {connection_error, Reason::any()}}.

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -25,7 +25,7 @@
 -include("eredis.hrl").
 
 %% API
--export([start_link/1, start_link/4, start_link/5, stop/1, select_database/2]).
+-export([start_link/4, start_link/5, stop/1, select_database/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -48,18 +48,6 @@
 %%
 %% API
 %%
-%% -type Args = [Option].
-%% -type Option = {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, integer()}.
--spec start_link(Args :: list() ) -> {ok, Pid::pid()} | {error, Reason::term()}.
-start_link(Args) ->
-    Host = proplists:get_value(host, Args, "127.0.0.1"),
-    Port = proplists:get_value(port, Args, 6379),
-    Database = proplists:get_value(database, Args, 0),
-    Password = proplists:get_value(password, Args, ""),
-    ReconnectSleep = proplists:get_value(reconnect_sleep, Args, 100),
-    start_link(Host, Port, Database, Password, ReconnectSleep).
-
-
 -spec start_link(Host::list(), Port::integer(), Database::integer(),
                  Password::string()) -> {ok, Pid::pid()} | {error, Reason::term()}.
 start_link(Host, Port, Database, Password) ->


### PR DESCRIPTION
When you have thousand of connections to an external redis you don't want to retry to reconnect every 100ms.

It's also useful to avoid the middleman worker in Poolboy to increase performance and instead be able to start it up directly .
