### PR TITLE
Support sending a pipeline of redis commands.

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -5,6 +5,7 @@
 
 -type return_value() :: binary() | [binary()].
 
+-type pipeline() :: [iolist()].
 
 %% Continuation data is whatever data returned by any of the parse
 %% functions. This is used to continue where we left off the next time


### PR DESCRIPTION
Hello! Here's another patch, it let's you send a bunch
of commands together without waiting for each one.
You get the results back as a list of all the results.

I added a new function eredis:qp for this, but I'm happy
to use a different name or convention, just let me know.
