### PR TITLE
Bugfix: eredis_client:stop/1 used to crash the caller process.

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -87,7 +87,7 @@ handle_call({request, Req}, From, State) ->
     do_request(Req, From, State);
 
 handle_call(stop, _From, State) ->
-    {stop, normal, State};
+    {stop, normal, ok, State};
 
 handle_call(_Request, _From, State) ->
     {reply, unknown_request, State}.


### PR DESCRIPTION
eredis_client:handle_call(stop, _From, State) used to return 3-element tuple, thus not replying to the caller and making it crash when gen_server stopped.

See:
-    http://www.erlang.org/doc/man/gen_server.html#Module:handle_call-3
-    https://github.com/erlang/otp/blob/master/lib/stdlib/src/gen_server.erl#L176-181
-    https://github.com/erlang/otp/blob/master/lib/stdlib/src/gen.erl#L204-224
