### PR TITLE
Fixes/xref

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,6 @@
 {erl_opts, []}.
 {cover_enabled, true}.
+%% basho_bench_driver_erldis calls undefined functions, so disable xref_checks.
+%% This allows this project to be used as a dependency by other rebar projects
+%% that use xref.
 {xref_checks, []}.


### PR DESCRIPTION
Add an xref_checks setting to the rebar.config. This enables xref to run cleanly on eredis when included as a dependency of another project using rebar.
