### PR TITLE
Fix return type spec

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -3,7 +3,7 @@
 -type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, integer()}.
 -type server_args() :: [option()].
 
--type return_value() :: binary() | [binary()].
+-type return_value() :: undefined | binary() | [binary()].
 
 -type pipeline() :: [iolist()].
 


### PR DESCRIPTION
Return type may be undefined for a GET with non-existent key and for a NULL multi-bulk reply.
