### PR TITLE
Add start/* functions for unsupervised startup

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -16,7 +16,8 @@
 -define(TIMEOUT, 5000).
 
 -export([start_link/0, start_link/1, start_link/2, start_link/3, start_link/4,
-         start_link/5, stop/1, q/2, q/3, qp/2, qp/3]).
+         start_link/5, start/0, start/2, start/3, start/4, start/5,
+         stop/1, q/2, q/3, qp/2, qp/3]).
 
 %% Exported for testing
 -export([create_multibulk/1]).
@@ -45,6 +46,27 @@ start_link(Host, Port, Database, Password, ReconnectSleep)
        is_integer(ReconnectSleep) ->
 
     eredis_client:start_link(Host, Port, Database, Password, ReconnectSleep).
+
+start() ->
+    start("127.0.0.1", 6379, 0, "").
+
+start(Host, Port) ->
+    start(Host, Port, 0, "").
+
+start(Host, Port, Database) ->
+    start(Host, Port, Database, "").
+
+start(Host, Port,  Database, Password) ->
+    start(Host, Port, Database, Password, 100).
+
+start(Host, Port, Database, Password, ReconnectSleep)
+  when is_list(Host);
+       is_integer(Port);
+       is_integer(Database);
+       is_list(Password);
+       is_integer(ReconnectSleep) ->
+
+    eredis_client:start(Host, Port, Database, Password, ReconnectSleep).
 
 
 %% @doc: Callback for starting from poolboy

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -28,7 +28,7 @@
 -include("eredis.hrl").
 
 %% API
--export([start_link/5, stop/1, select_database/2]).
+-export([start_link/5, start/5, stop/1, select_database/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -59,6 +59,8 @@
 start_link(Host, Port, Database, Password, ReconnectSleep) ->
     gen_server:start_link(?MODULE, [Host, Port, Database, Password, ReconnectSleep], []).
 
+start(Host, Port, Database, Password, ReconnectSleep) ->
+    gen_server:start(?MODULE, [Host, Port, Database, Password, ReconnectSleep], []).
 
 stop(Pid) ->
     gen_server:call(Pid, stop).


### PR DESCRIPTION
I have a need to attempt an eredis connection when redis itself might not be started. Added start/\* functions to allow starting up of eredis without linking to the spawned eredis processes.
