### PR TITLE
Get dialyzer to give eredis a clean bill of health

### DIFF
--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -3,7 +3,7 @@
           host :: string() | undefined,
           port :: integer() | undefined,
           password :: binary() | undefined,
-          reconnect_sleep :: integer() | undefined,
+          reconnect_sleep :: integer() | undefined | no_reconnect,
 
           socket :: port() | undefined,
           parser_state :: #pstate{} | undefined,

--- a/src/eredis_sub.erl
+++ b/src/eredis_sub.erl
@@ -35,7 +35,7 @@ start_link(Host, Port, Password, ReconnectSleep,
   when is_list(Host) andalso
        is_integer(Port) andalso
        is_list(Password) andalso
-       is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect andalso
+       (is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect) andalso
        (is_integer(MaxQueueSize) orelse MaxQueueSize =:= infinity) andalso
        (QueueBehaviour =:= drop orelse QueueBehaviour =:= exit) ->
 

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -30,7 +30,7 @@
                  Port::integer(),
                  Password::string(),
                  ReconnectSleep::reconnect_sleep(),
-                 MaxQueueSize::integer(),
+                 MaxQueueSize::integer() | infinity,
                  QueueBehaviour::drop | exit) ->
                         {ok, Pid::pid()} | {error, Reason::term()}.
 start_link(Host, Port, Password, ReconnectSleep, MaxQueueSize, QueueBehaviour) ->


### PR DESCRIPTION
The eredis_sub state record's reconnect_sleep field does not permit no_reconnect as a value, while this value is used to indicate that the client should not reconnect on error.  Additionally, the type specification for MaxQueueSize parameter to eredis_sub_client:start_link/6 allows only integers while the atom 'infinity' is used to indicate the absence of a limit on the queue size.

Also changed the use of parens in eredis_sub:start_linik/6 to be more consistent.
