### PR TITLE
Catch exception to make commands more robust

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -116,7 +116,11 @@ to_bulk(B) when is_binary(B) ->
 %% term_to_binary/1. For floats, throws {cannot_store_floats, Float}
 %% as we do not want floats to be stored in Redis. Your future self
 %% will thank you for this.
-to_binary(X) when is_list(X)    -> list_to_binary(X);
+to_binary(X) when is_list(X)    -> try list_to_binary(X) of
+                                       Y -> Y
+                                   catch
+                                       error:badarg -> term_to_binary(X)
+                                   end;
 to_binary(X) when is_atom(X)    -> list_to_binary(atom_to_list(X));
 to_binary(X) when is_binary(X)  -> X;
 to_binary(X) when is_integer(X) -> list_to_binary(integer_to_list(X));


### PR DESCRIPTION
### Issue

Currently, the client will crash if the user attempts to issue a query with a proplist or any unconventional list. This is because the client assumes in `eredis:to_binary/1` that all lists are strings.
### Example:

``` erlang
eredis:q(Client, ["SET", foo, [{a, b}, {c, d}]])
Exception: bad argument
```
### Resolution

If the list cannot be converted to binary cleanly, the client should fallback to `term_to_binary/1` as advertised in a catch block.
