### PR TITLE
Fix typo in Pubsub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Pubsub:
     1> eredis_sub:sub_example().
     received {subscribed,<<"foo">>,<0.34.0>}
     {<0.34.0>,<0.37.0>}
-    2> redis_sub:pub_example().
+    2> eredis_sub:pub_example().
     received {message,<<"foo">>,<<"bar">>,<0.34.0>}
 
 Pattern Subscribe:


### PR DESCRIPTION
`redis_sub:pub_example()` becomes `eredis_sub:pub_example()`
