### PR TITLE
Database undefined support

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -40,7 +40,7 @@ start_link(Host, Port,  Database, Password) ->
 start_link(Host, Port, Database, Password, ReconnectSleep)
   when is_list(Host),
        is_integer(Port),
-       is_integer(Database),
+       is_integer(Database) orelse Database == undefined,
        is_list(Password),
        is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect ->
 

--- a/test/eredis_tests.erl
+++ b/test/eredis_tests.erl
@@ -126,3 +126,6 @@ multibulk_test_() ->
      ?_assertThrow({cannot_store_floats, 123.5},
                    list_to_binary(create_multibulk(['SET', foo, 123.5])))
     ].
+
+undefined_database_test() ->
+    ?assertMatch({ok,_}, eredis:start_link("localhost", 6379, undefined)).


### PR DESCRIPTION
Hi, here is small patch to add support for undefined database option. With this set eredis should not send select command to redis. I need this for sentinel client, I currently working on. Also small fix for start_link function guard.
