### PR TITLE
Notify all consumers awaiting results upon receiving tcp_closed message

### DIFF
--- a/src/eredis.app.src
+++ b/src/eredis.app.src
@@ -1,6 +1,6 @@
 {application, eredis, [
     {description, "Erlang Redis Client"},
-    {vsn, "1.0.5"},
+    {vsn, "1.0.6"},
     {modules, [eredis, eredis_client, eredis_parser, eredis_sub, eredis_sub_client]},
     {registered, []},
     {applications, [kernel, stdlib]}


### PR DESCRIPTION
Hi there,

This patch was motivated by gen_server timeout errors we have been seeing under load using eredis.

Consumers in the redis_client's queue will be sent a `{error,
tcp_closed}` message if the connection to redis goes down. Since the
queue is reset as part of reconnect, this avoids consumers waiting for
a response they will never receive and hitting the gen_server:call
timeout.

This patch includes a small adjustment to the handle_info callback for
receiving TCP data in order to allow test code to fake a TCP closed
message. The fake close is achieved by sending a raw {tcp_closed,
fake_socket} message to redis_client. Since the unit tests use a real
connection to redis which will not have been closed, we have to be
able to handle additional data being received on the socket while
redis_client is in the process of handling the close and reconnect.
