### PR TITLE
only select database if it's not the default

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -300,6 +300,8 @@ connect(State) ->
 
 select_database(_Socket, undefined) ->
     ok;
+select_database(_Socket, <<"0">>) ->
+    ok;
 select_database(Socket, Database) ->
     do_sync_command(Socket, ["SELECT", " ", Database, "\r\n"]).
 


### PR DESCRIPTION
When using eredis with sentinel (which implements the normal redis protocol) you get the following crash:

```
{unexpected_data,{ok,<<"-ERR unknown command 'SELECT'\r\n">>}}
```

This is because sentinel doesn't implement `SELECT`. This PR makes it so that `select_database` is only actually called if the database isn't the default, which fixes the problem in a backwards compatible way.
