### PR TITLE
Add verbosity to eredis_sub reconnect phase

### DIFF
--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -183,6 +183,17 @@ handle_info({tcp_closed, _Socket}, State) ->
     %% signal we are "down"
     {noreply, State#state{socket = undefined}};
 
+%% Controller might want to be notified about every reconnect attempt
+handle_info(reconnect_attempt, State) ->
+    send_to_controller({eredis_reconnect_attempt, self()}, State),
+    {noreply, State};
+
+%% Controller might want to be notified about every reconnect failure and reason
+handle_info({reconnect_failed, Reason}, State) ->
+    send_to_controller({eredis_reconnect_failed, self(),
+                        {error, {connection_error, Reason}}}, State),
+    {noreply, State};
+
 %% Redis is ready to accept requests, the given Socket is a socket
 %% already connected and authenticated.
 handle_info({connection_ready, Socket}, #state{socket = undefined} = State) ->
@@ -322,11 +333,13 @@ do_sync_command(Socket, Command) ->
 %% successfully issuing the auth and select calls. When we have a
 %% connection, give the socket to the redis client.
 reconnect_loop(Client, #state{reconnect_sleep=ReconnectSleep}=State) ->
+    Client ! reconnect_attempt,
     case catch(connect(State)) of
         {ok, #state{socket = Socket}} ->
             gen_tcp:controlling_process(Socket, Client),
             Client ! {connection_ready, Socket};
-        {error, _Reason} ->
+        {error, Reason} ->
+            Client ! {reconnect_failed, Reason},
             timer:sleep(ReconnectSleep),
             reconnect_loop(Client, State);
         %% Something bad happened when connecting, like Redis might be

--- a/test/eredis_sub_tests.erl
+++ b/test/eredis_sub_tests.erl
@@ -108,6 +108,7 @@ pubsub_connect_disconnect_messages_test() ->
     gen_tcp:close(Sock),
     Sub ! {tcp_closed, Sock},
     ?assertEqual({eredis_disconnected, Sub}, wait_for_msg(S)),
+    ?assertEqual({eredis_reconnect_attempt, Sub}, wait_for_msg(S)),
     ?assertEqual({eredis_connected, Sub}, wait_for_msg(S)),
     eredis_sub:stop(Sub).
 


### PR DESCRIPTION
It is sometimes useful for `eredis` controller to know about reconnection attempts or failures (e.g. for statistics or notifying the end user) and this PR introduces such notifications.