### PR TITLE
reuse do_sync_command from eredis_client

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -27,6 +27,8 @@
 %% API
 -export([start_link/6, stop/1, select_database/2]).
 
+-export([do_sync_command/2]).
+
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -315,23 +315,8 @@ connect(State) ->
 authenticate(_Socket, <<>>) ->
     ok;
 authenticate(Socket, Password) ->
-    do_sync_command(Socket, ["AUTH", " ", Password, "\r\n"]).
+    eredis_client:do_sync_command(Socket, ["AUTH", " ", Password, "\r\n"]).
 
-%% @doc: Executes the given command synchronously, expects Redis to
-%% return "+OK\r\n", otherwise it will fail.
-do_sync_command(Socket, Command) ->
-    case gen_tcp:send(Socket, Command) of
-        ok ->
-            %% Hope there's nothing else coming down on the socket..
-            case gen_tcp:recv(Socket, 0, ?RECV_TIMEOUT) of
-                {ok, <<"+OK\r\n">>} ->
-                    ok;
-                Other ->
-                    {error, {unexpected_data, Other}}
-            end;
-        {error, Reason} ->
-            {error, Reason}
-    end.
 
 %% @doc: Loop until a connection can be established, this includes
 %% successfully issuing the auth and select calls. When we have a


### PR DESCRIPTION
Both `eredis_client` and `eredis_sub_client` use `do_sync_command`
the logic in both cases should be the same so there is no need
to duplicate this code.

Moreover `eredis_sub_client:do_sync_command` has a bug. The socket is not
set in `{active, false}` state before receiving data which in some cases
raise error `einval`.