### PR TITLE
[specs] return_value could be nonempty_list in cases of SCAN

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -5,7 +5,7 @@
 -type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
 -type server_args() :: [option()].
 
--type return_value() :: undefined | binary() | [binary()].
+-type return_value() :: undefined | binary() | [binary() | nonempty_list()].
 
 -type pipeline() :: [iolist()].
 


### PR DESCRIPTION
@see http://redis.io/commands/scan