### PR TITLE
Fix rebar 2.5.1 compile error

### DIFF
--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -22,7 +22,7 @@
 %%    gen_tcp:recv/2 with the desired size.
 
 -module(eredis_parser).
--include_lib("eredis.hrl").
+-include("eredis.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -export([init/0, parse/2]).

--- a/test/eredis_parser_tests.erl
+++ b/test/eredis_parser_tests.erl
@@ -6,7 +6,7 @@
 
 -module(eredis_parser_tests).
 
--include_lib("eredis.hrl").
+-include("eredis.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -import(eredis_parser, [parse/2, init/0, parse_bulk/1, parse_bulk/2,


### PR DESCRIPTION
change include_lib("eredis.hrl") to include("eredis.hrl") in eredis_parser.erl