### PR TITLE
Fix q() parameters in comment about usage

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -3,8 +3,8 @@
 %%
 %% Usage:
 %%   {ok, Client} = eredis:start_link().
-%%   {ok, <<"OK">>} = eredis:q(["SET", "foo", "bar"]).
-%%   {ok, <<"bar">>} = eredis:q(["GET", "foo"]).
+%%   {ok, <<"OK">>} = eredis:q(Client, ["SET", "foo", "bar"]).
+%%   {ok, <<"bar">>} = eredis:q(Client, ["GET", "foo"]).
 
 -module(eredis).
 -include("eredis.hrl").


### PR DESCRIPTION
Fixing usage comment providing the client as parameter when doing queries.