### PR TITLE
Modified authentication functions to accept password with spaces.

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -315,7 +315,7 @@ select_database(Socket, Database) ->
 authenticate(_Socket, <<>>) ->
     ok;
 authenticate(Socket, Password) ->
-    do_sync_command(Socket, ["AUTH", " ", Password, "\r\n"]).
+    do_sync_command(Socket, ["AUTH", " \"", Password, "\"\r\n"]).
 
 %% @doc: Executes the given command synchronously, expects Redis to
 %% return "+OK\r\n", otherwise it will fail.

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -326,7 +326,7 @@ connect(State) ->
 authenticate(_Socket, <<>>) ->
     ok;
 authenticate(Socket, Password) ->
-    eredis_client:do_sync_command(Socket, ["AUTH", " ", Password, "\r\n"]).
+    eredis_client:do_sync_command(Socket, ["AUTH", " \"", Password, "\"\r\n"]).
 
 
 %% @doc: Loop until a connection can be established, this includes


### PR DESCRIPTION
Hello,

This changes would fix a minor bug I found while using exredis (Elixir Redis library that uses eredis heavily). I was having problems connecting to my Redis database always receiving this error:

``` erlang
** (EXIT from #PID<0.163.0>) {:connection_error, {:authentication_error, {:unexpected_data, {:ok, "-ERR wrong number of arguments for 'auth' command\r\n"}}}}
```

In my Elixir configuration I had:

``` elixir
config :exredis,
  host: "localhost",
  port: 6379,
  password: "Password with spaces.",
  db: 1,
  reconnect: :no_reconnect,
  max_queue: :infinity
```

To make the library work with my password, I had to change the password field of the configuration to:

``` elixir
password: "\"Password with spaces\""
```

Tracing the bug, I got to the authentication functions in eredis. When I executed the following:

``` erlang
{ok, C} = eredis:start_link("localhost", 6379, 1, "Password with spaces.")
```

I got:

``` erlang
** exception exit: {connection_error,{authentication_error,{unexpected_data,{ok,<<"-ERR wrong number of arguments for 'auth' command\r\n">>}}}}
```

TL;DR: At the moment, eredis is not accepting passwords with spaces and this pull requests is to fix this bug.
