### PR TITLE
Non-blocking init

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -80,12 +80,8 @@ init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout]) ->
                    parser_state = eredis_parser:init(),
                    queue = queue:new()},
 
-    case connect(State) of
-        {ok, NewState} ->
-            {ok, NewState};
-        {error, Reason} ->
-            {stop, {connection_error, Reason}}
-    end.
+    self() ! initiate_connection,
+    {ok, State}.
 
 handle_call({request, Req}, From, State) ->
     do_request(Req, From, State);
@@ -134,24 +130,8 @@ handle_info({tcp_error, _Socket, _Reason}, State) ->
 %% clients. If desired, spawn of a new process which will try to reconnect and
 %% notify us when Redis is ready. In the meantime, we can respond with
 %% an error message to all our clients.
-handle_info({tcp_closed, _Socket}, #state{reconnect_sleep = no_reconnect,
-                                          queue = Queue} = State) ->
-    reply_all({error, tcp_closed}, Queue),
-    %% If we aren't going to reconnect, then there is nothing else for
-    %% this process to do.
-    {stop, normal, State#state{socket = undefined}};
-
-handle_info({tcp_closed, _Socket}, #state{queue = Queue} = State) ->
-    Self = self(),
-    spawn(fun() -> reconnect_loop(Self, State) end),
-
-    %% tell all of our clients what has happened.
-    reply_all({error, tcp_closed}, Queue),
-
-    %% Throw away the socket and the queue, as we will never get a
-    %% response to the requests sent on the old socket. The absence of
-    %% a socket is used to signal we are "down"
-    {noreply, State#state{socket = undefined, queue = queue:new()}};
+handle_info({tcp_closed, _Socket}, State) ->
+    maybe_reconnect(tcp_closed, State);
 
 %% Redis is ready to accept requests, the given Socket is a socket
 %% already connected and authenticated.
@@ -162,6 +142,14 @@ handle_info({connection_ready, Socket}, #state{socket = undefined} = State) ->
 %% that Poolboy uses to manage the connections.
 handle_info(stop, State) ->
     {stop, shutdown, State};
+
+handle_info(initiate_connection, #state{socket = undefined} = State) ->
+    case connect(State) of
+        {ok, NewState} ->
+            {noreply, NewState};
+        {error, Reason} ->
+            maybe_reconnect(Reason, State)
+    end;
 
 handle_info(_Info, State) ->
     {stop, {unhandled_message, _Info}, State}.
@@ -257,7 +245,7 @@ reply(Value, Queue) ->
         {empty, Queue} ->
             %% Oops
             error_logger:info_msg("Nothing in queue, but got value from parser~n"),
-            throw(empty_queue)
+            exit(empty_queue)
     end.
 
 %% @doc Send `Value' to each client in queue. Only useful for sending
@@ -334,6 +322,27 @@ do_sync_command(Socket, Command) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+maybe_reconnect(Reason, #state{reconnect_sleep = no_reconnect, queue = Queue} = State) ->
+    reply_all({error, Reason}, Queue),
+    %% If we aren't going to reconnect, then there is nothing else for
+    %% this process to do.
+    Reason1 = case Reason of
+                  tcp_closed -> normal;
+                  _Else -> Reason
+              end,
+    {stop, Reason1, State#state{socket = undefined}};
+maybe_reconnect(Reason, #state{queue = Queue} = State) ->
+    Self = self(),
+    spawn_link(fun() -> reconnect_loop(Self, State) end),
+
+    %% tell all of our clients what has happened.
+    reply_all({error, Reason}, Queue),
+
+    %% Throw away the socket and the queue, as we will never get a
+    %% response to the requests sent on the old socket. The absence of
+    %% a socket is used to signal we are "down"
+    {noreply, State#state{socket = undefined, queue = queue:new()}}.
 
 %% @doc: Loop until a connection can be established, this includes
 %% successfully issuing the auth and select calls. When we have a

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -80,8 +80,16 @@ init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout]) ->
                    parser_state = eredis_parser:init(),
                    queue = queue:new()},
 
-    self() ! initiate_connection,
-    {ok, State}.
+    case ReconnectSleep of
+        no_reconnect ->
+            case connect(State) of
+                {ok, _NewState} = Res -> Res;
+                {error, Reason} -> {stop, Reason}
+            end;
+        T when is_integer(T) ->
+            self() ! initiate_connection,
+            {ok, State}
+    end.
 
 handle_call({request, Req}, From, State) ->
     do_request(Req, From, State);
@@ -136,6 +144,7 @@ handle_info({tcp_closed, _Socket}, State) ->
 %% Redis is ready to accept requests, the given Socket is a socket
 %% already connected and authenticated.
 handle_info({connection_ready, Socket}, #state{socket = undefined} = State) ->
+    error_logger:info_msg("Connection is ready ~p:~p", [State#state.host, State#state.port]),
     {noreply, State#state{socket = Socket}};
 
 %% eredis can be used in Poolboy, but it requires to support a simple API
@@ -327,12 +336,10 @@ maybe_reconnect(Reason, #state{reconnect_sleep = no_reconnect, queue = Queue} = 
     reply_all({error, Reason}, Queue),
     %% If we aren't going to reconnect, then there is nothing else for
     %% this process to do.
-    Reason1 = case Reason of
-                  tcp_closed -> normal;
-                  _Else -> Reason
-              end,
-    {stop, Reason1, State#state{socket = undefined}};
+    {stop, normal, State#state{socket = undefined}};
 maybe_reconnect(Reason, #state{queue = Queue} = State) ->
+    error_logger:error_msg("Re-establishing connection to ~p:~p due to ~p",
+                           [State#state.host, State#state.port, Reason]),
     Self = self(),
     spawn_link(fun() -> reconnect_loop(Self, State) end),
 

--- a/test/eredis_tests.erl
+++ b/test/eredis_tests.erl
@@ -136,6 +136,16 @@ multibulk_test_() ->
 undefined_database_test() ->
     ?assertMatch({ok,_}, eredis:start_link("localhost", 6379, undefined)).
 
+connection_failure_on_start_no_reconnect_test() ->
+    Res = eredis:start_link("this_host_does_not_exist", 6379, 0, "", no_reconnect),
+    ?assertMatch({ok, _}, Res),
+    {ok, ClientPid} = Res,
+    process_flag(trap_exit, true),
+    IsDied = receive {'EXIT', ClientPid, _} -> died
+             after 1000 -> still_alive end,
+    process_flag(trap_exit, false),
+    ?assertEqual(died, IsDied).
+
 tcp_closed_test() ->
     C = c(),
     tcp_closed_rig(C).

--- a/test/eredis_tests.erl
+++ b/test/eredis_tests.erl
@@ -136,15 +136,24 @@ multibulk_test_() ->
 undefined_database_test() ->
     ?assertMatch({ok,_}, eredis:start_link("localhost", 6379, undefined)).
 
-connection_failure_on_start_no_reconnect_test() ->
-    Res = eredis:start_link("this_host_does_not_exist", 6379, 0, "", no_reconnect),
-    ?assertMatch({ok, _}, Res),
-    {ok, ClientPid} = Res,
+connection_failure_during_start_no_reconnect_test() ->
     process_flag(trap_exit, true),
-    IsDied = receive {'EXIT', ClientPid, _} -> died
+    Res = eredis:start_link("this_host_does_not_exist", 6379, 0, "", no_reconnect),
+    ?assertMatch({error, _}, Res),
+    IsDied = receive {'EXIT', _, _} -> died
              after 1000 -> still_alive end,
     process_flag(trap_exit, false),
     ?assertEqual(died, IsDied).
+
+connection_failure_during_start_reconnect_test() ->
+    process_flag(trap_exit, true),
+    Res = eredis:start_link("this_host_does_not_exist", 6379, 0, "", 100),
+    ?assertMatch({ok, _}, Res),
+    {ok, ClientPid} = Res,
+    IsDied = receive {'EXIT', ClientPid, _} -> died
+             after 400 -> still_alive end,
+    process_flag(trap_exit, false),
+    ?assertEqual(still_alive, IsDied).
 
 tcp_closed_test() ->
     C = c(),


### PR DESCRIPTION
Initial connection establishing process was moved out of init to avoid blocking or crashing a supervisor. Besides if reconnect is allowed it will be used even if connection has failed right after initialization.
Closes #44 

P.S.: I've also took a liberty to fix the improper use of `throw`. It's never caught, neither this behaviour is expected in tests.
