### PR TITLE
Fix error reporting in init functions.

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -84,7 +84,7 @@ init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout]) ->
         {ok, NewState} ->
             {ok, NewState};
         {error, Reason} ->
-            {stop, {connection_error, Reason}}
+            {stop, Reason}
     end.
 
 handle_call({request, Req}, From, State) ->

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -59,7 +59,7 @@ init([Host, Port, Password, ReconnectSleep, MaxQueueSize, QueueBehaviour]) ->
             ok = inet:setopts(NewState#state.socket, [{active, once}]),
             {ok, NewState};
         {error, Reason} ->
-            {stop, {connection_error, Reason}}
+            {stop, Reason}
     end.
 
 %% Set the controlling process. All messages on all channels are directed here.


### PR DESCRIPTION
The current code reports initial connection errors in this form:

```
{error, {connection_error, {connection_error, Reason}}}
```

because the init/1 functions add another layer of {connection_error, ...} on top of the connect/1 function.
