### PR TITLE
add eredis:start method

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -14,7 +14,8 @@
 -define(TIMEOUT, 5000).
 
 -export([start_link/0, start_link/1, start_link/2, start_link/3, start_link/4,
-         start_link/5, start_link/6, stop/1, q/2, q/3, qp/2, qp/3, q_noreply/2]).
+         start_link/5, start_link/6, start/0, start/1, start/2, start/3,
+         start/4, start/5, start/6, stop/1, q/2, q/3, qp/2, qp/3, q_noreply/2]).
 
 %% Exported for testing
 -export([create_multibulk/1]).
@@ -66,6 +67,42 @@ start_link(Args) ->
     ReconnectSleep = proplists:get_value(reconnect_sleep, Args, 100),
     ConnectTimeout = proplists:get_value(connect_timeout, Args, ?TIMEOUT),
     start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout).
+
+start() ->
+    start("127.0.0.1", 6379, 0, "").
+
+start(Host, Port) ->
+    start(Host, Port, 0, "").
+
+start(Host, Port, Database) ->
+    start(Host, Port, Database, "").
+
+start(Host, Port, Database, Password) ->
+    start(Host, Port, Database, Password, 100).
+
+start(Host, Port, Database, Password, ReconnectSleep) ->
+    start(Host, Port, Database, Password, ReconnectSleep, ?TIMEOUT).
+
+start(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout)
+  when is_list(Host),
+       is_integer(Port),
+       is_integer(Database) orelse Database == undefined,
+       is_list(Password),
+       is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect,
+       is_integer(ConnectTimeout) ->
+
+    eredis_client:start(Host, Port, Database, Password,
+                        ReconnectSleep, ConnectTimeout).
+
+-spec start(server_args()) -> {ok, Pid::pid()} | {error, Reason::term()}.
+start(Args) ->
+    Host           = proplists:get_value(host, Args, "127.0.0.1"),
+    Port           = proplists:get_value(port, Args, 6379),
+    Database       = proplists:get_value(database, Args, 0),
+    Password       = proplists:get_value(password, Args, ""),
+    ReconnectSleep = proplists:get_value(reconnect_sleep, Args, 100),
+    ConnectTimeout = proplists:get_value(connect_timeout, Args, ?TIMEOUT),
+    start(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout).
 
 stop(Client) ->
     eredis_client:stop(Client).

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -25,7 +25,7 @@
 -include("eredis.hrl").
 
 %% API
--export([start_link/6, stop/1, select_database/2]).
+-export([start_link/6, start/6, stop/1, select_database/2]).
 
 -export([do_sync_command/2]).
 
@@ -60,6 +60,17 @@
 start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout) ->
     gen_server:start_link(?MODULE, [Host, Port, Database, Password,
                                     ReconnectSleep, ConnectTimeout], []).
+
+-spec start(Host::list(),
+                 Port::integer(),
+                 Database::integer() | undefined,
+                 Password::string(),
+                 ReconnectSleep::reconnect_sleep(),
+                 ConnectTimeout::integer() | undefined) ->
+                        {ok, Pid::pid()} | {error, Reason::term()}.
+start(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout) ->
+    gen_server:start(?MODULE, [Host, Port, Database, Password,
+                              ReconnectSleep, ConnectTimeout], []).
 
 
 stop(Pid) ->


### PR DESCRIPTION
Common test's init_per_group/2 has an issue with starting linked process:
it terminates process started with start_link method beforehand.

So I have some tests that use groups but eredis does not have start method (only start_link).

It would be useful for such issues to have ordinary start method (without link).

