### PR TITLE
Optimize binary operations

### DIFF
--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -15,8 +15,6 @@
 %% of erldis.
 %%
 %% Future improvements:
-%%  * Instead of building a binary all the time in the continuation,
-%%    build an iolist
 %%  * When we return a bulk continuation, we also include the size of
 %%    the bulk. The caller may use this to explicitly call
 %%    gen_tcp:recv/2 with the desired size.


### PR DESCRIPTION
Hello!

We use eredis widely in many Erlang and Elixir projects. It's an awesome library, but recently we had an issue with an edge case.

We noticed that one of our services experienced strange short peaks of load, during which all VM scheduler threads were consumed.

After some research we found that the peaks were caused by calling Redis GET command over keys holding very large values (~150MB). Having looked into eredis sources we found that eredis parser does not behave very well against this particular case: it accumulates binary data of response recreating binary each time:

```erlang
parse_bulk({IntSize, Acc0}, Data) ->
    Acc = <<Acc0/binary, Data/binary>>,
```

etc. When the size of a bulk is large, reallocating happens many thousand times (since the response comes in many thousands of pieces) and possibly causes quadratic memory consumption for a short term of time.

So we implemented an iolist-based variant of parsing (it even had beed suggested in the comments).

There are also some benchmarks measuring CPU consumption of both variants on large and relatively small keys: https://github.com/savonarola/eredis_bench

Thanks! 

