### PR TITLE
Don't block forever on tcp send

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -33,6 +33,8 @@
 
 -define(NL, "\r\n").
 
--define(SOCKET_OPTS, [binary, {active, once}, {packet, raw}, {reuseaddr, true}]).
+-define(SOCKET_OPTS, [binary, {active, once}, {packet, raw}, {reuseaddr, true},
+                      {send_timeout, ?SEND_TIMEOUT}, {send_timeout_close, true}]).
 
 -define(RECV_TIMEOUT, 5000).
+-define(SEND_TIMEOUT, 5000).


### PR DESCRIPTION
If, for some reason, redis locks and stops
handling requests the sender's tcp buffer will
fill up and block the client, protect against
this by specifying a maximum send timeout.