### PR TITLE
Feature addition for q_async

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -14,7 +14,8 @@
 -define(TIMEOUT, 5000).
 
 -export([start_link/0, start_link/1, start_link/2, start_link/3, start_link/4,
-         start_link/5, start_link/6, stop/1, q/2, q/3, qp/2, qp/3, q_noreply/2]).
+         start_link/5, start_link/6, stop/1, q/2, q/3, qp/2, qp/3, q_noreply/2,
+         q_async/2, q_async/3]).
 
 %% Exported for testing
 -export([create_multibulk/1]).
@@ -101,6 +102,18 @@ qp(Client, Pipeline, Timeout) ->
 %% @see q/2
 q_noreply(Client, Command) ->
     cast(Client, Command).
+
+-spec q_async(Client::client(), Command::[any()]) -> ok.
+% @doc Executes the command, and sends a message to this process with the response (with either error or success). Message is of the form `{response, Reply}', where `Reply' is the reply expected from `q/2'.
+q_async(Client, Command) ->
+    q_async(Client, Command, self()).
+
+-spec q_async(Client::client(), Command::[any()], Pid::pid()|atom()) -> ok.
+%% @doc Executes the command, and sends a message to `Pid' with the response (with either or success).
+%% @see 1_async/2
+q_async(Client, Command, Pid) when is_pid(Pid) ->
+    Request = {request, create_multibulk(Command), Pid},
+    gen_server:cast(Client, Request).
 
 %%
 %% INTERNAL HELPERS

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -108,6 +108,15 @@ handle_cast({request, Req}, State) ->
             {noreply, State1}
     end;
 
+handle_cast({request, Req, Pid}, State) ->
+    case do_request(Req, Pid, State) of
+        {reply, Reply, State1} ->
+            safe_send(Pid, {response, Reply}),
+            {noreply, State1};
+        {noreply, State1} ->
+            {noreply, State1}
+    end;
+
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -279,8 +288,17 @@ receipient({_, From, _}) ->
 
 safe_reply(undefined, _Value) ->
     ok;
+safe_reply(Pid, Value) when is_pid(Pid) ->
+    safe_send(Pid, {response, Value});
 safe_reply(From, Value) ->
     gen_server:reply(From, Value).
+
+safe_send(Pid, Value) ->
+    try erlang:send(Pid, Value)
+    catch
+        Err:Reason ->
+            error_logger:info_msg("Failed to send message to ~p with reason ~p~n", [Pid, {Err, Reason}])
+    end.
 
 %% @doc: Helper for connecting to Redis, authenticating and selecting
 %% the correct database. These commands are synchronous and if Redis


### PR DESCRIPTION
Makes a request against eredis server similar to q/2, but supplies a pid to send the response (or error) back to rather than making a synchronous call.