### PR TITLE
Use binary:match/2 instead of re:run/2

### DIFF
--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -259,9 +259,9 @@ parse_simple({incomplete_simple, Buffer}, NewData0) ->
 %% INTERNAL HELPERS
 %%
 get_newline_pos({B, _}) ->
-    case re:run(B, ?NL) of
-        {match, [{Pos, _}]} -> Pos;
-        nomatch -> undefined
+    case binary:match(B, <<?NL>>) of
+       {Pos, _} -> Pos;
+       nomatch -> undefined
     end.
 
 buffer_create() ->


### PR DESCRIPTION
According to `eprof`, `re:run/2` takes significant amount of processing time (36%):
```
****** Process <0.380.0>    -- 100.00 % of profiled time *** 
FUNCTION                              CALLS        %      TIME  [uS / CALLS]
--------                              -----  -------      ----  [----------]
eredis_parser:parse_simple/2             39     0.00       189  [      4.85]
lists:split/2                           812     0.01       871  [      1.07]
queue:in_r/2                           9741     0.02      3349  [      0.34]
eredis_client:do_pipeline/3            3246     0.04      4954  [      1.53]
eredis_parser:parse_simple/1          16298     0.04      5919  [      0.36]
prim_inet:setopts/2                   21542     0.07     10335  [      0.48]
gen_server:try_dispatch/4             21542     0.10     14066  [      0.65]
prim_inet:ctl_cmd/3                   21542     0.11     15189  [      0.71]
gen_server:handle_common_reply/6      21543     0.11     15769  [      0.73]
prim_inet:encode_opt_val/1            21542     0.13     18045  [      0.84]
erlang:port_control/3                 21542     0.15     20155  [      0.94]
lists:reverse/2                        4871     0.15     21018  [      4.31]
prim_inet:enc_opt_val/2               43084     0.16     21911  [      0.51]
inet:setopts/2                        21542     0.18     24417  [      1.13]
eredis_client:handle_info/2           21542     0.19     25684  [      1.19]
gen_server:try_dispatch/3             21542     0.19     25807  [      1.20]
inet:'-setopts/2-lc$^0/1-0-'/1        43084     0.23     31734  [      0.74]
lists:split/3                        198056     0.38     52303  [      0.26]
prim_inet:send/3                     195834     0.44     60414  [      0.31]
inet_tcp:send/2                      195834     0.46     63032  [      0.32]
eredis_parser:do_parse_multibulk/2   196106     0.47     65072  [      0.33]
gen_server:decode_msg/8              217376     0.53     73641  [      0.34]
gen_server:handle_msg/5              217376     0.53     73960  [      0.34]
eredis_parser:return_result/3        227176     0.66     90887  [      0.40]
eredis_client:handle_response/2      227176     0.68     94122  [      0.41]
eredis_parser:init/0                 205847     0.75    103650  [      0.50]
erlang:port_get_data/1               195834     0.76    105328  [      0.54]
eredis_parser:parse_multibulk/2       21290     0.80    110149  [      5.17]
eredis_client:safe_reply/2           196106     0.80    110416  [      0.56]
eredis_client:handle_call/3          195834     0.80    111042  [      0.57]
lists:reverse/1                      199353     0.85    117268  [      0.59]
eredis_parser:parse_multibulk/1      196448     0.87    120912  [      0.62]
queue:in/2                           195834     0.94    129955  [      0.66]
eredis_client:reply/2                205847     0.97    134842  [      0.66]
inet_db:lookup_socket/1              195834     1.00    139026  [      0.71]
eredis_client:do_request/3           192588     1.01    139714  [      0.73]
gen_server:try_handle_call/4         195834     1.06    146728  [      0.75]
gen_tcp:send/2                       195834     1.07    148324  [      0.76]
gen_server:loop/6                    217377     1.10    151828  [      0.70]
queue:out/1                          205847     1.27    176134  [      0.86]
eredis_parser:parse/2                227176     1.35    186429  [      0.82]
eredis_parser:do_parse_multibulk/3   567214     1.44    199651  [      0.35]
erlang:setelement/3                  423011     1.87    259331  [      0.61]
erlang:binary_to_list/1              559439     2.14    296140  [      0.53]
eredis_parser:parse_bulk/1           370854     2.18    301041  [      0.81]
erts_internal:port_control/3          21542     2.30    318771  [     14.80]
erlang:list_to_integer/1             559439     2.36    326688  [      0.58]
erlang:port_command/3                195834     2.99    413498  [      2.11]
eredis_parser:get_newline_pos/1      577082     3.46    478610  [      0.83]
gen_server:reply/2                   196106     5.26    727844  [      3.71]
erts_internal:port_command/3         195834    18.67   2583608  [     13.19]
re:run/2                             577082    35.89   4965387  [      8.60]
----------------------------------  -------  -------  --------  [----------]
Total:                              9276308  100.00%  13835157  [      1.49]
```
With `re:run/2` taking around 8.5 usec per call.
Replacing `re:run/2` with `binary:match/2` improves the situation a bit:
```
****** Process <0.380.0>    -- 100.00 % of profiled time *** 
FUNCTION                               CALLS        %      TIME  [uS / CALLS]
--------                               -----  -------      ----  [----------]
eredis_parser:parse_simple/2              58     0.00       294  [      5.07]
lists:split/2                           3475     0.02      2979  [      0.86]
queue:in_r/2                           12000     0.03      4065  [      0.34]
eredis_parser:parse_simple/1           20080     0.06      8523  [      0.42]
eredis_client:do_pipeline/3             4000     0.07      9415  [      2.35]
prim_inet:setopts/2                    26712     0.10     13369  [      0.50]
gen_server:try_dispatch/4              26712     0.11     15049  [      0.56]
gen_server:handle_common_reply/6       26712     0.14     18627  [      0.70]
prim_inet:ctl_cmd/3                    26712     0.16     20757  [      0.78]
prim_inet:encode_opt_val/1             26712     0.16     21420  [      0.80]
lists:reverse/2                        10950     0.18     24275  [      2.22]
gen_server:try_dispatch/3              26712     0.20     26385  [      0.99]
erlang:port_control/3                  26712     0.20     26738  [      1.00]
inet:setopts/2                         26712     0.20     26800  [      1.00]
prim_inet:enc_opt_val/2                53424     0.22     29713  [      0.56]
eredis_client:handle_info/2            26712     0.25     32857  [      1.23]
inet:'-setopts/2-lc$^0/1-0-'/1         53424     0.28     37586  [      0.70]
lists:split/3                         239774     0.50     67586  [      0.28]
prim_inet:send/3                      232096     0.52     70092  [      0.30]
eredis_parser:do_parse_multibulk/2    232096     0.56     75274  [      0.32]
inet_tcp:send/2                       232096     0.60     80403  [      0.35]
gen_server:decode_msg/8               258808     0.61     81432  [      0.31]
gen_server:handle_msg/5               258808     0.67     89390  [      0.35]
eredis_client:handle_response/2       269681     0.78    104782  [      0.39]
eredis_parser:return_result/3         269681     0.81    109004  [      0.40]
erlang:port_get_data/1                232096     0.89    118847  [      0.51]
eredis_parser:init/0                  244096     0.97    129433  [      0.53]
eredis_client:safe_reply/2            232096     0.98    131161  [      0.57]
eredis_parser:parse_multibulk/2        25527     1.00    134409  [      5.27]
eredis_parser:parse_multibulk/1       232533     1.13    151434  [      0.65]
eredis_client:handle_call/3           232096     1.14    152562  [      0.66]
lists:reverse/1                       236096     1.15    153523  [      0.65]
queue:in/2                            232096     1.18    158044  [      0.68]
eredis_client:reply/2                 244096     1.19    159043  [      0.65]
eredis_client:do_request/3            228096     1.20    160701  [      0.70]
inet_db:lookup_socket/1               232096     1.23    165238  [      0.71]
gen_tcp:send/2                        232096     1.32    177300  [      0.76]
gen_server:loop/6                     258808     1.40    187143  [      0.72]
gen_server:try_handle_call/4          232096     1.64    219677  [      0.95]
eredis_parser:parse/2                 269681     1.69    226714  [      0.84]
queue:out/1                           244096     1.77    237035  [      0.97]
eredis_parser:do_parse_multibulk/3    675936     1.88    252162  [      0.37]
erlang:setelement/3                   501777     2.37    316797  [      0.63]
erlang:binary_to_list/1               666447     2.47    330957  [      0.50]
erlang:list_to_integer/1              666447     2.72    363612  [      0.55]
eredis_parser:parse_bulk/1            443533     2.89    387134  [      0.87]
erts_internal:port_control/3           26712     2.90    388216  [     14.53]
erlang:port_command/3                 232096     3.15    421879  [      1.82]
eredis_parser:get_newline_pos/1       688124     4.23    565836  [      0.82]
gen_server:reply/2                    232096     5.83    780417  [      3.36]
binary:match/2                        688124    20.36   2726528  [      3.96]
erts_internal:port_command/3          232096    23.89   3198850  [     13.78]
----------------------------------  --------  -------  --------  [----------]
Total:                              11051948  100.00%  13391467  [      1.21]
```
With `binary:match/2` taking around 4 usec and reducing relative processing time to 20%.