### PR TITLE
Reset parser_state on disconnect

### DIFF
--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -180,8 +180,8 @@ handle_info({tcp_closed, _Socket}, State) ->
     spawn(fun() -> reconnect_loop(Self, State) end),
 
     %% Throw away the socket. The absence of a socket is used to
-    %% signal we are "down"
-    {noreply, State#state{socket = undefined}};
+    %% signal we are "down"; discard possibly patrially parsed data
+    {noreply, State#state{socket = undefined, parser_state = eredis_parser:init()}};
 
 %% Controller might want to be notified about every reconnect attempt
 handle_info(reconnect_attempt, State) ->


### PR DESCRIPTION
It seems, that the disconnect can be initiated by redis-side in case when client-subscription takes messages too slow. Eredis reconnects, and sends `eredis_connected` messge to controlling process, which resubsribes.

In that case the buffer from previous connection might still contain patrial response from previous response. 

To be concrete, I get the following error 

```
17:28:00.088 [error] gen_server <0.357.0> terminated with reason: no match of right hand value <<"\r\n*3\r\n$9\r\nsubscribe\r\n$9\r\ntasks.out\r\n:1\r\n*3\r\n$7\r\nmessage\r\n$9\r\ntasks.out\r\n$560\r\n{\"last_status\":\"595\",\"fail_reason\":\"...">> in eredis_parser:do_parse_bulk/1 line 207
17:28:00.088 [error] CRASH REPORT Process <0.357.0> with 2 neighbours exited with reason: no match of right hand value 
```

With the proposed PR the error has gone. 

