### PR TITLE
Unix domain socket support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ copy and paste the following into a shell to try out Eredis:
     {ok, <<"OK">>} = eredis:q(C, ["SET", "foo", "bar"]).
     {ok, <<"bar">>} = eredis:q(C, ["GET", "foo"]).
 
+To connect to a Redis instance listening on a Unix domain socket:
+
+    {ok, C1} = eredis:start_link({local, "/var/run/redis.sock"}, 0).
+
 MSET and MGET:
 
 ```erlang
@@ -114,7 +118,7 @@ To start the client, use any of the `eredis:start_link/0,1,2,3,4,5`
 functions. They all include sensible defaults. `start_link/5` takes
 the following arguments:
 
-* Host, dns name or ip adress as string
+* Host, dns name or ip adress as string; or unix domain socket as {local, Path} (available in OTP 19+)
 * Port, integer, default is 6379
 * Database, integer or 0 for default database
 * Password, string or empty string([]) for no password

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -47,7 +47,8 @@ start_link(Host, Port, Database, Password, ReconnectSleep) ->
     start_link(Host, Port, Database, Password, ReconnectSleep, ?TIMEOUT).
 
 start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout)
-  when is_list(Host),
+  when is_list(Host) orelse
+            (is_tuple(Host) andalso tuple_size(Host) =:= 2 andalso element(1, Host) =:= local),
        is_integer(Port),
        is_integer(Database) orelse Database == undefined,
        is_list(Password),

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -306,7 +306,11 @@ safe_send(Pid, Value) ->
 %% {SomeError, Reason}.
 connect(State) ->
     {ok, {AFamily, Addr}} = get_addr(State#state.host),
-    case gen_tcp:connect(Addr, State#state.port,
+    Port = case AFamily of
+        local -> 0;
+        _ -> State#state.port
+    end,
+    case gen_tcp:connect(Addr, Port,
                          [AFamily | ?SOCKET_OPTS], State#state.connect_timeout) of
         {ok, Socket} ->
             case authenticate(Socket, State#state.password) of
@@ -324,6 +328,8 @@ connect(State) ->
             {error, {connection_error, Reason}}
     end.
 
+get_addr({local, Path}) ->
+    {ok, {local, {local, Path}}};
 get_addr(Hostname) ->
     case inet:parse_address(Hostname) of
         {ok, {_,_,_,_} = Addr} ->         {ok, {inet, Addr}};


### PR DESCRIPTION
Allows connecting to Redis instances listening on Unix domain socket, e.g.,
```
{ok, C} = eredis:start_link({local, "/tmp/redis-server.sock"}, 0).
```

Requires OTP 19+.

Issue #83 