### PR TITLE
Fix dialyzer -reported issue

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -189,7 +189,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%--------------------------------------------------------------------
 
--spec do_request(Req::iolist(), From::pid(), #state{}) ->
+-spec do_request(Req::iolist(), From::undefined|pid(), #state{}) ->
                         {noreply, #state{}} | {reply, Reply::any(), #state{}}.
 %% @doc: Sends the given request to redis. If we do not have a
 %% connection, returns error.


### PR DESCRIPTION
We seem to be calling do_request with undefined; we might as well document it and get rid of that dialyzer warning