### PR TITLE
Export eredis:client() type

### DIFF
--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -26,7 +26,7 @@
                   {atom(),atom()} |
                   {global,term()} |
                   {via,atom(),term()}.
-
+-export_type([client/0]).
 %%
 %% PUBLIC API
 %%


### PR DESCRIPTION
This is useful to have when writing clients that carry around an eredis client in their state.