### PR TITLE
redirect README users to the official source at Nordix/eredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### This source code is no longer maintained. Official Hex.pm source was moved to [Nordix/eredis](https://github.com/Nordix/eredis/)
+
 # eredis
 
 Non-blocking Redis client with focus on performance and robustness.
@@ -80,15 +82,15 @@ received {message,<<"foo">>,<<"bar">>,<0.34.0>}
 ```
 
 Pattern Subscribe:
-    
+
 ```erl
-1> eredis_sub:psub_example(). 
+1> eredis_sub:psub_example().
 received {subscribed,<<"foo*">>,<0.33.0>}
 {<0.33.0>,<0.36.0>}
 2> eredis_sub:ppub_example().
 received {pmessage,<<"foo*">>,<<"foo123">>,<<"bar">>,<0.33.0>}
 ok
-3> 
+3>
 ```
 
 EUnit tests:


### PR DESCRIPTION
Source for Hex.pm package was moved to https://github.com/Nordix/eredis/.

This PR highlights this in the README to redirect users with potential issues/PRs.

Fixes #128.